### PR TITLE
Bugfix - use 'name' instead of 'GetDisplayName()'

### DIFF
--- a/src/Our.Umbraco.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Our.Umbraco.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -99,7 +99,7 @@ namespace Our.Umbraco.AzureSSO
 
 		private string DisplayName(ClaimsPrincipal claimsPrincipal, string defaultValue)
 		{
-			var displayName = claimsPrincipal.GetDisplayName();
+			var displayName = claimsPrincipal.FindFirstValue("name");
 
 			return !string.IsNullOrWhiteSpace(displayName) ? displayName: defaultValue;
 		}


### PR DESCRIPTION
So it turns out that `GetDisplayName()` didn't actually get the `"name"` claim..it tries for `"preferred_username"` before trying for `"name"` which, apparently, is populated and set to an email address for me.  

Sorry - thought I'd checked that `GetDisplayName()` was returning what I wanted before submitting the PR!