### PR TITLE
Add Net10 targetting for Umbraco 17+ and target for getStatus -> getStatusAsync for HealthCheck

### DIFF
--- a/src/Umbraco.Community.AzureSSO/HealthChecks/AzureSSOHealthCheck.cs
+++ b/src/Umbraco.Community.AzureSSO/HealthChecks/AzureSSOHealthCheck.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +5,7 @@ using Umbraco.Cms.Core.HealthChecks;
 
 namespace Umbraco.Community.AzureSSO.HealthChecks
 {
-    [HealthCheck(HealthCheckId, HealthCheckName, Description = "Checks the Azure SSO config to ensure it is valid.", Group = "Configuration")]
+	[HealthCheck(HealthCheckId, HealthCheckName, Description = "Checks the Azure SSO config to ensure it is valid.", Group = "Configuration")]
 	public class AzureSSOHealthCheck : HealthCheck
 	{
 		private const string HealthCheckId = "07F7DA0A-D351-4347-92B3-9B607E1D38BB";
@@ -19,31 +18,39 @@ namespace Umbraco.Community.AzureSSO.HealthChecks
 			_configuration = configuration;
 		}
 
+#if NET10_0
+		public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
+		{
+			return GetStatuses();
+		}
+#else
 		public override async Task<IEnumerable<HealthCheckStatus>> GetStatus()
 		{
-			var statuses = new List<HealthCheckStatus>();
+			return GetStatuses();
+		}
+#endif
 
+		private List<HealthCheckStatus> GetStatuses()
+		{
+			var statuses = new List<HealthCheckStatus>();
 			if (!_configuration.IsValid())
 			{
-				// TODO : We really need specific feedback for this to be useful
 				statuses.Add(new HealthCheckStatus("Configuration Invalid.")
 				{
 					Description = "Check AzureSSO configuration",
 					ResultType = StatusResultType.Error
 				});
 			}
-
-			if(!statuses.Any())
+			else
 			{
 				statuses.Add(new HealthCheckStatus("Configuration valid.")
 				{
 					ResultType = StatusResultType.Success
 				});
 			}
-
 			return statuses;
 		}
-		
+
 		public override HealthCheckStatus ExecuteAction(HealthCheckAction action) => new("How did you get here?")
 		{
 			ResultType = StatusResultType.Info

--- a/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
+++ b/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageId>Umbraco.Community.AzureSSO</PackageId>
 		<Version>2.0.0</Version>
@@ -33,6 +33,19 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Identity.Web" Version="2.21.1" />
 	</ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
+		<PackageReference Include="Umbraco.Cms.Web.Common">
+			<Version>17.0.0</Version>
+		</PackageReference>
+		<PackageReference Include="Umbraco.Cms.Api.Management">
+			<Version>17.0.0</Version>
+		</PackageReference>
+		<PackageReference Include="Umbraco.Cms.Infrastructure">
+			<Version>17.0.0</Version>
+		</PackageReference>
+	</ItemGroup>	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
 		<PackageReference Include="Umbraco.Cms.Web.Common">
 			<Version>15.0.0</Version>
@@ -77,6 +90,9 @@
 			<Version>10.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<DefineConstants>$(DefineConstants);NEW_BACKOFFICE</DefineConstants>
+	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
 		<DefineConstants>$(DefineConstants);NEW_BACKOFFICE</DefineConstants>
 	</PropertyGroup>


### PR DESCRIPTION
## Describe your changes

Added net10 targeting for Umbraco 17+ as noticed the healthcheck fails to run on a umb17.1.0 install, due to the changed method name.. 
getStatusAsync vs GetStatus 

Also updated Microsoft.Identity.Web to v3.8.3 for v10 as I seemed to have issues with the 2.21.1 on my setup.

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code

