### PR TITLE
Move icons package registry outside of foreach loop to prevent duplicate registrations

### DIFF
--- a/src/Umbraco.Community.AzureSSO/AzureSSOManifestReader.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOManifestReader.cs
@@ -60,7 +60,7 @@ namespace Umbraco.Community.AzureSSO
 						["meta"] = meta
 					};
 
-					extensions.Add(extension);	
+					extensions.Add(extension);
 				}
 
 				var icons = new JsonObject


### PR DESCRIPTION
## Describe your changes

While working on an Umbraco 17 upgrade project, I encountered the following error:

<img width="397" height="64" alt="duplicate-registries" src="https://github.com/user-attachments/assets/39c8e3c1-6078-4959-8b2e-9d0468e91f77" />

The site in question uses more than one Azure SSO profile group. When the manifest reader loops through both of these groups it registers the icons package under the same alias (`Umbraco.Community.AzureSSO.Icons`). I have moved the code to add the icons package to the manifest outside of the foreach loop to prevent this.

## Link to issue

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code

