### PR TITLE
Fix missing comma for example settings in README-v13.md

### DIFF
--- a/README-v13.md
+++ b/README-v13.md
@@ -26,7 +26,7 @@ You'll need to configure the package by adding the following section to the root
     "DefaultGroups": [
 		  "editor"
 	  ],
-    "Icon": "icon-microsoft-fill"
+    "Icon": "icon-microsoft-fill",
     "ButtonStyle": "btn-microsoft",
     "LogUnmappedRolesAsWarning": false
 },


### PR DESCRIPTION
Simple typo correction, quick fix while I was there or I'd forget to come back to it :) 